### PR TITLE
Added vulnerability note to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ Licensor assumes:
 
 3. All `*.js` source files, except those in `node_modules`, are the
    author's work.
+
+ > Note: Running `npm audit --only=dev` will report security vulnerabilities due to dev dependencies of the [tap](https://www.npmjs.com/package/tap) test library. The project requires version `10.7.2` to support Node versions 4 to 8, which are incompatible with newer releases, which as of January 18, 2020 is version 14.10.6. Running `npm audit --production` should report no vulnerabilities.


### PR DESCRIPTION
As discussed in #19, this pull request adds a note on the node versions this project explicitly supports, as well as additional information clarifying that the security vulnerabilities reported by `npm audit` affect the [tap](https://www.npmjs.com/package/tap) test library but production environments are not affected.

Please feel free to rewrite or restructure as necessary or preferable